### PR TITLE
Added simply logging

### DIFF
--- a/django_ajax/decorators.py
+++ b/django_ajax/decorators.py
@@ -4,12 +4,16 @@ Decorators
 from __future__ import unicode_literals
 
 from functools import wraps
+import logging
+import sys, traceback
 
 from django.http import HttpResponseBadRequest
 from django.utils.decorators import available_attrs
 
 from django_ajax.shortcuts import render_to_json
 
+# Set logging
+log = logging.getLogger(__name__)
 
 def ajax(function=None, mandatory=True):
     """
@@ -67,6 +71,9 @@ def ajax(function=None, mandatory=True):
                 try:
                     return render_to_json(func(request, *args, **kwargs))
                 except Exception as exception:
+                    type, value, tb = sys.exc_info()
+                    log.error(exception.message + ' with json ' + str(request.POST))
+                    log.error('\n'.join(traceback.format_tb(tb)))
                     return render_to_json(exception)
             else:
                 # return standard response


### PR DESCRIPTION
Hello!

Debugging can be very hard with your current implementation.
I've added an simple logger instance which logs the traceback on an Exception.

Output is like:

```
[24/Aug/2014 20:18:48] ERROR [django_ajax.decorators:inner():75] list index out of range with json <QueryDict: {u'action': [u'1'], u'caller': [u'2'], u'data': [u'{"username": "xxxxx", "password": "xxxxx"}']}>
[24/Aug/2014 20:18:48] ERROR [django_ajax.decorators:inner():76]   File "/usr/lib/python2.7/site-packages/django_ajax/decorators.py", line 72, in inner
    return render_to_json(func(request, *args, **kwargs))

  File "/var/gui/interface/views.py", line 70, in api_request
    api.account_actions(request, action, data, values)

  File "/usr/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)

  File "/var/gui/interface/utils.py", line 54, in account_actions
    return account_views.settings_get(request, values)

  File "/usr/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)

  File "/var/gui/account/views.py", line 161, in settings_get
    settings = settings[2]

  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 177, in __getitem__
    return list(qs)[0]
```

Greets
Manuel
