### PR TITLE
Encoder now checks that an iterable is not a string

### DIFF
--- a/django_ajax/encoder.py
+++ b/django_ajax/encoder.py
@@ -35,7 +35,19 @@ class LazyJSONEncoder(json.JSONEncoder):
         except TypeError:
             pass
         else:
-            return list(iterable)
+            # Make sure the iterable is not a string
+            is_string = False
+
+            try:
+                if isinstance(obj, unicode):
+                    is_string = True
+            except NameError:
+                pass
+
+            if isinstance(obj, bytes):
+                is_string = True
+
+            return force_text(obj) if is_string else list(iterable)
 
         # this handlers Models
         if isinstance(obj.__class__, ModelBase):


### PR DESCRIPTION
An error bytestring currently passes as an iterable in Python 3. The response is a list of ascii decimals instead of a string.
Explicitly checking if the iterable is a string fixes the issue.
