### PR TITLE
Allow a custom JSON encoder to be given to the decorator.

### DIFF
--- a/django_ajax/decorators.py
+++ b/django_ajax/decorators.py
@@ -11,7 +11,7 @@ from django.utils.decorators import available_attrs
 from django_ajax.shortcuts import render_to_json
 
 
-def ajax(function=None, mandatory=True):
+def ajax(function=None, mandatory=True, **ajax_kwargs):
     """
     Decorator who guesses the user response type and translates to a serialized
     JSON response. Usage::
@@ -65,7 +65,7 @@ def ajax(function=None, mandatory=True):
             if request.is_ajax():
                 # return json response
                 try:
-                    return render_to_json(func(request, *args, **kwargs))
+                    return render_to_json(func(request, *args, **kwargs), **ajax_kwargs)
                 except Exception as exception:
                     return render_to_json(exception)
             else:

--- a/django_ajax/encoder.py
+++ b/django_ajax/encoder.py
@@ -11,7 +11,7 @@ from django.utils.encoding import force_text
 from django.db.models.base import ModelBase
 
 
-class LazyJSONEncoder(json.JSONEncoder):
+class LazyJSONEncoderMixin(object):
     """
     A JSONEncoder subclass that handle querysets and models objects.
     Add how handle your type of object here to use when dump json
@@ -41,7 +41,11 @@ class LazyJSONEncoder(json.JSONEncoder):
         if isinstance(obj.__class__, ModelBase):
             return force_text(obj)
 
-        return super(LazyJSONEncoder, self).default(obj)
+        return super(LazyJSONEncoderMixin, self).default(obj)
+
+
+class LazyJSONEncoder(LazyJSONEncoderMixin, json.JSONEncoder):
+    pass
 
 
 def serialize_to_json(data, *args, **kwargs):


### PR DESCRIPTION
I found that there were situations in which I needed to pass in a custom JSON encoder to the ajax decorator. I noticed that there was an interface in the lower levels of the system to allow for a custom encoder to be passed in, but not via the decorator (or at least I couldn't see a way to do it, please correct me if I'm wrong).

I've added some keyword arguments to the decorator for passing in the "cls" value and handed them off to the appropriate JSON encoding routines.

I've also modified the LazyJSONEncoder class to be based on a mixin, as I need to override the encoder with some enhancements.

Cheers!