### PR TITLE
Ajax-plugin: "beforeSend", "complete" events; single instance ajax request

### DIFF
--- a/django_ajax/static/django_ajax/js/jquery.ajax-plugin.js
+++ b/django_ajax/static/django_ajax/js/jquery.ajax-plugin.js
@@ -59,7 +59,13 @@
                 onSuccess: function(response) {
                     processData(response, $this);
                 },
-                onError: onError
+                onError: onError,
+                onBeforeSend: function (xhr, settings) {
+                    return beforeSend(xhr, settings, $this);
+                },
+                onComplete: function (xhr, textStatus) {
+                    return complete(xhr, textStatus, $this);
+                }
             });
         else
             alert('jquery.ajax.js is required');
@@ -215,6 +221,45 @@
             try {
                 success_function = window[success_function];
                 $.isFunction(success_function) && success_function(response.content);
+            } catch (e) {
+                alert(e.name + '\n' + e.message);
+            }
+        }
+    }
+
+    function beforeSend(jqXHR, settings, $el) {
+        var beforeSend_function = $el.data('beforesend');
+        var single = $el.data('ajaxsingle');
+        if (single) {
+            if($el.data('__hasajaxinstance'))
+            {
+                return false;
+            } else {
+                $el.data('__hasajaxinstance', true);
+            }
+        }
+        if (beforeSend_function) {
+            try {
+                beforeSend_function = window[beforeSend_function];
+                if ($.isFunction(beforeSend_function)) {
+                    return beforeSend_function(jqXHR, settings, $el);
+                }
+            } catch (e) {
+                alert(e.name + '\n' + e.message);
+            }
+        }
+    }
+
+    function complete(jqXHR, textStatus, $el) {
+        var complete_function = $el.data('complete');
+        var single = $el.data('ajaxsingle');
+        if (single && $el.data('__hasajaxinstance')) {
+            $el.removeData('__hasajaxinstance');
+        }
+        if (complete_function) {
+            try {
+                complete_function = window[complete_function];
+                $.isFunction(complete_function) && complete_function(jqXHR, textStatus, $el);
             } catch (e) {
                 alert(e.name + '\n' + e.message);
             }

--- a/django_ajax/static/django_ajax/js/jquery.ajax.js
+++ b/django_ajax/static/django_ajax/js/jquery.ajax.js
@@ -58,7 +58,7 @@ var ajax = function (url, options) {
                 xhr.setRequestHeader("X-CSRFToken", csrftoken);
             }
 
-            onBeforeSend && onBeforeSend(xhr, settings);
+            if(onBeforeSend) return onBeforeSend(xhr, settings);
         },
         success: function( response ){
             switch (response.status) {


### PR DESCRIPTION
**Purpose**: I need to create animation while loading data by ajax and prevent another query for the html tag (users can click on the link over and over again). 
**Implementation**: append events "beforeSend", "complete" in ajax-plugin and realize single instance of ajax request by html elements in ajax-plugin.
**Example**:

``` html
<a href="{% url 'myapp:update' %}" class="btn btn-primary" 
   data-ajax="true" 
   data-replace="#munst_list"
   data-beforesend="beforeSend"
   data-complete="complete"
   data-ajaxsingle="true">Update</a>
```

JS:

``` javascript
function beforeSend(xhr, settings, $this) {
    $('#loading').show();
}
function complete(xhr, settings, $this) {
    $('#loading').hide();
}
```
